### PR TITLE
Simplify label map

### DIFF
--- a/reference/args.txt
+++ b/reference/args.txt
@@ -1,10 +1,10 @@
 [DEFAULT]
-TrainImageFolder = /data/xview3/data/reprojected_dataset/uuid/train
-TrainChipsPath = /data/xview3/data/reprojected_dataset/uuid/train_chips
-TrainLabelFile = /data/xview3/ground_truth_labels/20210825/train.csv
-ValImageFolder = /data/xview3/data/reprojected_dataset/uuid/validation
-ValChipsPath = /data/xview3/data/reprojected_dataset/uuid/validation_chips
-ValLabelFile = /data/xview3/ground_truth_labels/20210825/validation.csv
+TrainImageFolder = /home/shared-data/xview3/data/tiny/train
+TrainChipsPath =  /home/shared-data/xview3/data/tiny/chips
+TrainLabelFile =  /home/shared-data/xview3/labels/train.csv
+ValImageFolder =  /home/shared-data/xview3/data/tiny/validation
+ValChipsPath = /home/shared-data/xview3/data/tiny/chips
+ValLabelFile = /home/shared-data/xview3/labels/validation.csv
 NumPreprocWorkers = 8
 IsDistributed = False
 

--- a/reference/dataloader.py
+++ b/reference/dataloader.py
@@ -317,6 +317,34 @@ class XView3Dataset(object):
         print(f"Number of Unique Chips: {len(self.chip_indices)}")
         print("Initialization complete")
 
+    @staticmethod
+    def get_label_map():
+        """
+        Not currently used, but useful for laying out how the
+        fishing vs. non-fishing labels can be separated.
+        """
+        background_labels = ["background"]
+        non_fishing_labels = [
+            "non_fishing",
+        ]
+        fishing_labels = [
+            "fishing",
+        ]
+        personnel_labels = [
+            "personnel",
+        ]
+        other_labels = ["other"]
+
+        label_map = {a: NONFISHING for a in non_fishing_labels}
+        label_map.update({a: FISHING for a in fishing_labels})
+        label_map.update({a: NONVESSEL for a in personnel_labels})
+        label_map.update({a: NONVESSEL for a in other_labels})
+
+        # Treat background as a separate class for classifier
+        # to support adding empty chips for training
+        label_map.update({a: BACKGROUND for a in background_labels})
+
+        return label_map
 
     def __len__(self):
         return len(self.chip_indices)

--- a/reference/inference.py
+++ b/reference/inference.py
@@ -70,8 +70,9 @@ def main(args):
         pin_memory=True,
     )
 
+    num_classes = len(np.unique(list(test_data_unlabeled.label_map.values())))
     model_eval = xView3BaselineModel(
-        num_classes=len(test_data_unlabeled.label_map.keys()),
+        num_classes=num_classes,
         num_channels=len(test_data_unlabeled.channels),
         image_mean=image_mean,
         image_std=image_std,

--- a/reference/train.py
+++ b/reference/train.py
@@ -179,8 +179,9 @@ def main(config):
         image_std = np.load(f"{train_chips_path}/data_std.npy")
 
     # instantiate model with a number of classes
+    num_classes =  len(np.unique(list(train_data.label_map.values())))
     model = xView3BaselineModel(
-        num_classes=len(train_data.label_map.keys()),
+        num_classes=num_classes,
         num_channels=len(train_data.channels),
         image_mean=image_mean,
         image_std=image_std,


### PR DESCRIPTION
* Simplifies label map in `dataloader.py` to reduce confusion (no functional changes)
* Adjusts baseline model `num_classes` kwarg calls to use reference label map `values` rather than `keys` -- no effect on previously trained models, but eliminates unused classes in model output
* Updates `inference.py`, `train_reference.ipynb`, and `train.py` to reflect these changes