### PR TITLE
Fix bug in fishing precision computation

### DIFF
--- a/reference/metric.py
+++ b/reference/metric.py
@@ -193,7 +193,7 @@ def compute_fishing_class_performance(preds, gt, tp_inds, vessel_inds):
         else:
             if gt[pair["gt_idx"]]:
                 c_fn_inds.append(pair)
-            elif gt[pair["gt_idx"]]:
+            else:
                 c_fp_inds.append(pair)
 
     return c_tp_inds, c_fp_inds, c_fn_inds, c_tn_inds


### PR DESCRIPTION
Fix bug in metric.py where false positives were ignored when computing fishing class performance (precision was always 1.0). Now they are correctly accounted for as in compute_vessel_class_performance.